### PR TITLE
🔧 Fix: storybook cli 에서 deprecated 옵션인 `-s public` 제거

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "lint": "next lint",
     "tsc": "tsc --noEmit",
     "storybook": "start-storybook -p 6006",
-    "build-storybook": "build-storybook -s public",
+    "build-storybook": "build-storybook",
     "postinstall": "husky install"
   },
   "dependencies": {


### PR DESCRIPTION
## 📮 관련 이슈
- resolved: #21 

## ⛳️ 작업 내용

<!-- 작업한 사항을 간략하게 적어주세요 -->
- `package.json`에서 `-s public`을 제거한다.

## 🌱 PR 포인트
- storybook cli로 static file을 지정하는 방식은 deprecated라고 한다.

## 📸 스크린샷
|스크린샷|스크린샷|
|:--:|:--:|
|파일첨부바람|파일첨부바람|

## 📎 레퍼런스

<!-- 참고한 레퍼런스가 있다면 기록해주세요 -->
- https://storybook.js.org/docs/react/configure/images-and-assets#%EF%B8%8F-deprecated-serving-static-files-via-storybook-cli