### PR TITLE
✨ [YW-76] Feat: 아이콘 컴포넌트

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -63,6 +63,12 @@
     ],
 
     "import/no-duplicates": "error",
+    "import/namespace": [
+      "error",
+      {
+        "allowComputed": true
+      }
+    ],
 
     "simple-import-sort/imports": "error",
     "simple-import-sort/exports": "error"

--- a/.storybook/main.js
+++ b/.storybook/main.js
@@ -33,6 +33,9 @@ module.exports = {
       test: /\.svg$/,
       enforce: "pre",
       loader: require.resolve("@svgr/webpack"),
+      options: {
+        svgo: false,
+      },
     });
 
     config.resolve.alias["@"] = path.resolve(__dirname, "../src/");

--- a/next.config.js
+++ b/next.config.js
@@ -5,7 +5,14 @@ const nextConfig = {
   webpack: (config) => {
     config.module.rules.push({
       test: /.svg$/,
-      use: ["@svgr/webpack"],
+      use: [
+        {
+          loader: "@svgr/webpack",
+          options: {
+            svgo: false,
+          },
+        },
+      ],
     });
     return config;
   },

--- a/src/components/common/Icon/Icon.stories.tsx
+++ b/src/components/common/Icon/Icon.stories.tsx
@@ -1,0 +1,26 @@
+import type { ComponentMeta, ComponentStory } from "@storybook/react";
+import React from "react";
+
+import Icon from ".";
+
+export default {
+  title: "components/common/Icon",
+  component: Icon,
+  argTypes: {
+    width: {
+      control: "select",
+      options: [10, 20, 30, 40, 50],
+    },
+    height: {
+      control: "select",
+      options: [10, 20, 30, 40, 50],
+    },
+  },
+} as ComponentMeta<typeof Icon>;
+
+export const Default: ComponentStory<typeof Icon> = ({ ...args }) => <Icon {...args} />;
+Default.args = {
+  name: "back",
+  width: 30,
+  height: 30,
+};

--- a/src/components/common/Icon/assets.ts
+++ b/src/components/common/Icon/assets.ts
@@ -1,0 +1,5 @@
+export { default as back } from "/public/icon/back.svg";
+export { default as cancel } from "/public/icon/cancel.svg";
+export { default as logo } from "/public/icon/logo.svg";
+export { default as menu } from "/public/icon/menu.svg";
+export { default as mockProfile } from "/public/icon/mockProfile.svg";

--- a/src/components/common/Icon/index.tsx
+++ b/src/components/common/Icon/index.tsx
@@ -1,0 +1,15 @@
+import type { SVGProps } from "react";
+
+import * as Icons from "./assets";
+
+type IconName = keyof typeof Icons;
+
+interface Props extends SVGProps<SVGSVGElement> {
+  name: IconName;
+}
+const Icon = ({ name, ...rest }: Props) => {
+  const Svg = Icons[name];
+  return <Svg {...rest} />;
+};
+
+export default Icon;

--- a/src/components/common/Icon/index.tsx
+++ b/src/components/common/Icon/index.tsx
@@ -1,15 +1,23 @@
-import type { SVGProps } from "react";
+import type { FC, SVGProps } from "react";
 
 import * as Icons from "./assets";
 
-type IconName = keyof typeof Icons;
+// FIXME classname 동적 할당 문제
+const colors = {
+  black: "[&_*]:fill-black [&_*]:stroke-black",
+  brand: "[&_*]:fill-brand [&_*]:stroke-brand",
+  bookmark: "[&_*]:fill-bookmark [&_*]:stroke-bookmark",
+  default: "",
+};
 
 interface Props extends SVGProps<SVGSVGElement> {
-  name: IconName;
+  name: keyof typeof Icons;
+  color?: keyof typeof colors;
 }
-const Icon = ({ name, ...rest }: Props) => {
-  const Svg = Icons[name];
-  return <Svg {...rest} />;
+const Icon = ({ name, color = "default", ...rest }: Props) => {
+  const Svg = Icons[name] as FC<SVGProps<SVGSVGElement>>;
+
+  return <Svg className={colors[color]} {...rest} />;
 };
 
 export default Icon;

--- a/src/types/svg.d.ts
+++ b/src/types/svg.d.ts
@@ -1,0 +1,7 @@
+declare module "*.svg" {
+  import React = require("react");
+
+  export const ReactComponent: React.FC<React.SVGProps<SVGSVGElement>>;
+  const src: string;
+  export default src;
+}


### PR DESCRIPTION
## 📮 관련 이슈
- resolved: #26 

## ⛳️ 작업 내용

### `<Icon />` 컴포넌트 제작
1. width, height로 사이즈 조절 가능
2. color로 fill, stroke 컬러 조절 가능
3. name으로 파일 이름 타입 체크 가능

### svgr 설정 수정
```
   options: {
        svgo: false,
      },
```
svgr의 svg 최적화 옵션을 꺼서 SVG 컴포넌트에 스타일 props가 잘 적용되도록 조치했습니다
- 기존 : viewBox 속성이 사라져서 width, height props를 조절해도 svg 사이즈가 바뀌지 않았음

### eslint 설정 추가
```
"import/namespace": [
      "error",
      {
        "allowComputed": true
      }
    ],
```
`import/namespace` 규칙을 설정하여 모듈의 namespace에서 computed key가 잘 동작하도록 조치했습니다
- `Icons[key] `

### Use Case
```tsx
<Icon name="menu" width={40} height={40} color="brand" />
<Icon name="menu" />
```
- `color, width, height`는 optional 값이며 설정하지 않을 시 해당 svg의 기본 값으로 동작합니다 

## 🌱 PR 포인트
1. **svg 파일 추가 시 `common/Icon/assets.ts`에 re-export 해주어야 타입체크가 가능합니다**
    1. `export { default as menu } from "/public/icon/menu.svg";`
2. tailwind에서 color를 동적 할당 하는데 어려움이 있어 일단 `black, brand, bookmark` 컬러로만 제한하였습니다

## 📸 스크린샷
|스토리북|-|
|:--:|:--:|
|![image](https://user-images.githubusercontent.com/74011724/206959372-c681e188-0b95-41e3-a085-5a241a828600.png)|-|

## 📎 레퍼런스

<!-- 참고한 레퍼런스가 있다면 기록해주세요 -->