### PR TITLE
✨ feat: useLocalStorage 구현

### DIFF
--- a/src/application/hooks/common/index.ts
+++ b/src/application/hooks/common/index.ts
@@ -1,0 +1,4 @@
+export * from "./useColoredText";
+export * from "./useInput";
+export * from "./useLocalStorage";
+export * from "./useValidation";

--- a/src/application/hooks/common/useLocalStorage.ts
+++ b/src/application/hooks/common/useLocalStorage.ts
@@ -1,0 +1,96 @@
+import type { SetStateAction } from "react";
+import { useCallback, useEffect, useState } from "react";
+
+import { safeLocalStorage } from "@/application/util";
+
+export type Serializable<T> = T extends
+  | string
+  | number
+  | boolean
+  | unknown[]
+  | Record<string, unknown>
+  ? T
+  : never;
+
+interface StorageStateOptions<T> {
+  defaultValue?: Serializable<T>;
+}
+interface StorageStateOptionsWithDefaultValue<T> extends StorageStateOptions<T> {
+  defaultValue: Serializable<T>;
+}
+
+export function useLocalStorage<T>(
+  key: string,
+): readonly [
+  Serializable<T> | undefined,
+  (value: SetStateAction<Serializable<T> | undefined>) => void,
+];
+export function useLocalStorage<T>(
+  key: string,
+  { defaultValue }: StorageStateOptionsWithDefaultValue<T>,
+): readonly [Serializable<T>, (value: SetStateAction<Serializable<T>>) => void];
+export function useLocalStorage<T>(
+  key: string,
+  { defaultValue }: StorageStateOptions<T>,
+): readonly [
+  Serializable<T> | undefined,
+  (value: SetStateAction<Serializable<T> | undefined>) => void,
+];
+export function useLocalStorage<T>(
+  key: string,
+  { defaultValue }: StorageStateOptions<T> = {},
+): readonly [
+  Serializable<T> | undefined,
+  (value: SetStateAction<Serializable<T> | undefined>) => void,
+] {
+  const getValue = useCallback(<T>() => {
+    const item = safeLocalStorage.get(key);
+
+    if (item == null) {
+      return defaultValue;
+    }
+
+    try {
+      const result = JSON.parse(item);
+
+      if (result == null) {
+        return defaultValue;
+      }
+
+      return result as T;
+    } catch {
+      // NOTE: JSON 객체가 아닌 경우
+      return defaultValue;
+    }
+  }, [defaultValue, key]);
+
+  /**
+   * NOTE: hydration error 때문에 useState의 초기값으로 defaultValue을 넣어줌
+   * @see https://nextjs.org/docs/messages/react-hydration-error
+   */
+  const [state, setState] = useState<Serializable<T> | undefined>(defaultValue);
+
+  useEffect(() => {
+    setState(getValue());
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  const set = useCallback(
+    (value: SetStateAction<Serializable<T> | undefined>) => {
+      setState((curr) => {
+        const nextValue = typeof value === "function" ? value(curr) : value;
+
+        if (nextValue == null) {
+          safeLocalStorage.remove(key);
+        } else {
+          safeLocalStorage.set(key, JSON.stringify(nextValue));
+        }
+
+        return nextValue;
+      });
+    },
+    [key],
+  );
+
+  return [state, set];
+}

--- a/src/application/hooks/index.ts
+++ b/src/application/hooks/index.ts
@@ -1,0 +1,1 @@
+export * from "./common";

--- a/src/application/util/index.ts
+++ b/src/application/util/index.ts
@@ -1,0 +1,1 @@
+export * from "./storage";

--- a/src/application/util/storage.ts
+++ b/src/application/util/storage.ts
@@ -1,0 +1,66 @@
+export interface Storage {
+  get(key: string): string | null;
+
+  set(key: string, value: string): void;
+
+  remove(key: string): void;
+}
+
+class MemoStorage implements Storage {
+  private storage = new Map<string, string>();
+
+  public get(key: string) {
+    return this.storage.get(key) || null;
+  }
+
+  public set(key: string, value: string) {
+    this.storage.set(key, value);
+  }
+
+  public remove(key: string) {
+    this.storage.delete(key);
+  }
+}
+
+class LocalStorage implements Storage {
+  public static canUse(): boolean {
+    const TEST_KEY = generateTestKey();
+
+    // NOTE: 사용자가 쿠키 차단을 하는 경우 or SSR환경에서는 localStorage 접근 시에 예외가 발생합니다.
+    try {
+      localStorage.setItem(TEST_KEY, "test");
+      localStorage.removeItem(TEST_KEY);
+      return true;
+    } catch (err) {
+      return false;
+    }
+  }
+
+  public get(key: string) {
+    return localStorage.getItem(key);
+  }
+
+  public set(key: string, value: string) {
+    localStorage.setItem(key, value);
+  }
+
+  public remove(key: string) {
+    localStorage.removeItem(key);
+  }
+}
+
+function generateTestKey() {
+  return new Array(4)
+    .fill(null)
+    .map(() => Math.random().toString(36).slice(2))
+    .join("");
+}
+
+export function generateStorage(): Storage {
+  if (LocalStorage.canUse()) {
+    return new LocalStorage();
+  }
+  return new MemoStorage();
+}
+
+export const safeLocalStorage = generateStorage();

--- a/src/components/search/SearchItem/index.tsx
+++ b/src/components/search/SearchItem/index.tsx
@@ -1,6 +1,6 @@
 import type { HTMLAttributes } from "react";
 
-import { useColoredText } from "@/application/hooks/common/useColoredText";
+import { useColoredText } from "@/application/hooks";
 import { Chip } from "@/components/common/Chip";
 import { Icon } from "@/components/common/Icon";
 

--- a/src/pages/search/index.tsx
+++ b/src/pages/search/index.tsx
@@ -1,4 +1,4 @@
-import { useInput } from "@/application/hooks/common/useInput";
+import { useInput } from "@/application/hooks";
 import { Navigation } from "@/components/common/Navigation";
 import { SearchInput } from "@/components/search/SearchInput";
 import { SearchItem } from "@/components/search/SearchItem";


### PR DESCRIPTION
## 📮 관련 이슈
- resolved: #37 

## ⛳️ 작업 내용

<!-- 작업한 사항을 간략하게 적어주세요 -->
- [x] `useLocalStorage` 구현
- [x] `safeLocalStorage` 클래스 구현(`localStorage` 를 wrapping 해주는 클래스
- [x] `name export` 수정

## 🌱 PR 포인트
- Thanks to @elbica 👍
- `safeLocalStorage` 클래스는 localStorage를 사용할 수 없는 환경에 대응할 수 있도록 해줘요.
- `useLocalStorage` 함수 시그니처

  ```jsx
  function useLocalStorage<T>(
    key: string,
    options: {
      defaultValue: T;
    }
  );
  ```
- `useLocalStorage` 사용법

  ```tsx
  const Component = () => {
    // Recommend: generic을 넣어주면 타입 추론이 잘 됨
    const [value, setValue] = useLocalStorage<number>('key', { defaultValue: 0 });
    const handleClick = () => {
      setValue(prev => prev + 1);
    }
    return <button onClick={handleClick}>{value}</button>
  }
  ```
- hooks 폴더에 있는 hook들을 import할 때 상위 레벨의 경로로 name export할 수 있도록 수정했어요.
  ```tsx
  // before
  import { useInput } from "@/application/hooks/common/useInput";

  // after
  import { useInput } from "@/application/hooks";
  ```

## 📸 스크린샷
|스크린샷|스크린샷|
|:--:|:--:|
|파일첨부바람|파일첨부바람|

## 📎 레퍼런스

<!-- 참고한 레퍼런스가 있다면 기록해주세요 -->
- useLocalStorage 구현에 참고한 것
  - https://github.com/mash-up-kr/muzily-web/blob/develop/hooks/commons/useLocalStorage/index.ts
  - https://github.com/toss/slash/blob/e728a933d1/packages/react/react/src/hooks/useStorageState.ts
- [Typescript 함수 오버로딩](https://radlohead.gitbook.io/typescript-deep-dive/type-system/functions?q=%EC%98%A4%EB%B2%84%EB%A1%9C%EB%94%A9#undefined-2)