### PR TITLE
✨ 밈 상세페이지 SSG 적용

### DIFF
--- a/src/application/hooks/api/meme/index.ts
+++ b/src/application/hooks/api/meme/index.ts
@@ -1,4 +1,4 @@
-import type { QueryFunctionContext } from "@tanstack/react-query";
+import type { QueryClient, QueryFunctionContext } from "@tanstack/react-query";
 import { useInfiniteQuery } from "@tanstack/react-query";
 
 import { useSuspendedQuery } from "@/application/hooks/api/core";
@@ -17,6 +17,8 @@ export const useMemeDetailById = (id: string) => {
 
   return { ...data, ...rest };
 };
+export const prefetchMemeDetailById = (id: string, queryClient: QueryClient) =>
+  queryClient.prefetchQuery(QUERY_KEYS.getMemeDetailById(id), () => api.meme.getMemeDetailById(id));
 
 /**
  * 인기 밈 리스트 API

--- a/src/application/hooks/api/meme/index.ts
+++ b/src/application/hooks/api/meme/index.ts
@@ -13,6 +13,7 @@ export const useMemeDetailById = (id: string) => {
   const { data, ...rest } = useSuspendedQuery({
     queryKey: QUERY_KEYS.getMemeDetailById(id),
     queryFn: () => api.meme.getMemeDetailById(id),
+    staleTime: Infinity,
   });
 
   return { ...data, ...rest };

--- a/src/application/hooks/api/meme/index.ts
+++ b/src/application/hooks/api/meme/index.ts
@@ -8,16 +8,19 @@ import { QUERY_KEYS } from "./queryKey";
 /**
  * 밈 상세 조회 API
  * @param id 상세 조회할 밈 id
+ * @desc staleTime 0 : 조회수 증가를 위해 바로 브라우저에서 재요청
+ *
  */
 export const useMemeDetailById = (id: string) => {
   const { data, ...rest } = useSuspendedQuery({
     queryKey: QUERY_KEYS.getMemeDetailById(id),
     queryFn: () => api.meme.getMemeDetailById(id),
-    staleTime: Infinity,
+    staleTime: 0,
   });
 
   return { ...data, ...rest };
 };
+
 export const fetchMemeDetailById = (id: string, queryClient: QueryClient) =>
   queryClient.fetchQuery(QUERY_KEYS.getMemeDetailById(id), () => api.meme.getMemeDetailById(id));
 

--- a/src/application/hooks/api/meme/index.ts
+++ b/src/application/hooks/api/meme/index.ts
@@ -17,8 +17,8 @@ export const useMemeDetailById = (id: string) => {
 
   return { ...data, ...rest };
 };
-export const prefetchMemeDetailById = (id: string, queryClient: QueryClient) =>
-  queryClient.prefetchQuery(QUERY_KEYS.getMemeDetailById(id), () => api.meme.getMemeDetailById(id));
+export const fetchMemeDetailById = (id: string, queryClient: QueryClient) =>
+  queryClient.fetchQuery(QUERY_KEYS.getMemeDetailById(id), () => api.meme.getMemeDetailById(id));
 
 /**
  * 인기 밈 리스트 API

--- a/src/application/hooks/api/tags/index.ts
+++ b/src/application/hooks/api/tags/index.ts
@@ -1,3 +1,4 @@
+import type { QueryClient } from "@tanstack/react-query";
 import { useQuery } from "@tanstack/react-query";
 
 import { useSuspendedQuery } from "@/application/hooks/api/core";
@@ -58,6 +59,10 @@ export const useGetMemeTagsById = (id: string) => {
   const { data, ...rest } = useSuspendedQuery({
     queryKey: QUERY_KEYS.getMemeTagsById(id),
     queryFn: () => api.tags.getMemeTagsById(id),
+    staleTime: Infinity,
   });
   return { ...data, ...rest };
 };
+
+export const fetchMemeTagsById = (id: string, queryClient: QueryClient) =>
+  queryClient.fetchQuery(QUERY_KEYS.getMemeTagsById(id), () => api.tags.getMemeTagsById(id));

--- a/src/application/util/seo.ts
+++ b/src/application/util/seo.ts
@@ -21,5 +21,5 @@ export const TITLE = {
    * 검색페이지(/search)
    */
   search: `밈찾기 | ${APP_NAME}`,
-  memeDetail: `밈 상세 페이지`,
+  memeDetail: (title: string) => `${title} | ${APP_NAME}`,
 } as const;

--- a/src/components/common/Drawer/Drawer.tsx
+++ b/src/components/common/Drawer/Drawer.tsx
@@ -31,30 +31,39 @@ const DrawerContent = ({ children, className, direction }: DrawerContentProps) =
   const isOpen = useDrawerContext();
 
   return (
-    <section
+    <div
       className={className}
-      css={[
-        css`
-          visibility: hidden;
-          transform: translateX(${direction === "left" ? "-110%" : "110%"});
-          will-change: transform;
-          transition: transform 0.4s ease, visibility 0s ease 0.4s;
-          position: absolute;
-          inset: 0;
-          padding-inline: 1.8rem;
-          height: calc(100vh - 5.4rem);
-          background: white;
-        `,
-        isOpen &&
-          css`
-            visibility: visible;
-            transform: translateX(0);
-            transition: transform 0.4s ease;
-          `,
-      ]}
+      css={css`
+        position: fixed;
+        pointer-events: ${isOpen ? "auto" : "none"};
+        min-height: calc(100vh - 5.4rem);
+        inset: 0;
+        overflow: hidden;
+      `}
     >
-      {children}
-    </section>
+      <section
+        css={[
+          css`
+            visibility: hidden;
+            transform: translateX(${direction === "left" ? "-110%" : "110%"});
+            will-change: transform;
+            transition: transform 0.4s ease, visibility 0s ease 0.4s;
+            overflow: auto;
+            padding-inline: 1.8rem;
+            height: 100%;
+            background: white;
+          `,
+          isOpen &&
+            css`
+              visibility: visible;
+              transform: translateX(0);
+              transition: transform 0.4s ease;
+            `,
+        ]}
+      >
+        {children}
+      </section>
+    </div>
   );
 };
 

--- a/src/components/common/Layout/Layout.tsx
+++ b/src/components/common/Layout/Layout.tsx
@@ -1,24 +1,13 @@
 import type { PropsWithChildren } from "react";
-import { useRef } from "react";
 
 import { pretendard, suit, tossface } from "@/styles/fonts";
 
-import { GlobalScrollContext } from "./context";
-
 export const Layout = ({ children }: PropsWithChildren) => {
-  const ref = useRef<HTMLElement>(null);
   return (
-    <GlobalScrollContext.Provider value={ref}>
-      <div
-        className={`${pretendard.variable} ${suit.variable} ${tossface.variable} flex h-screen w-screen justify-center bg-gray-100 font-pretendard`}
-      >
-        <main
-          className="relative flex w-[48rem] flex-col overflow-y-auto overflow-x-hidden bg-white px-18 shadow-lg"
-          ref={ref}
-        >
-          {children}
-        </main>
-      </div>
-    </GlobalScrollContext.Provider>
+    <main
+      className={`relative min-h-screen ${pretendard.variable} ${suit.variable} ${tossface.variable} mx-auto max-w-[48rem] bg-white px-18 font-pretendard shadow-lg`}
+    >
+      {children}
+    </main>
   );
 };

--- a/src/components/common/Layout/context.tsx
+++ b/src/components/common/Layout/context.tsx
@@ -1,7 +1,0 @@
-import type { RefObject } from "react";
-import { createContext, useContext } from "react";
-
-export const GlobalScrollContext = createContext<RefObject<HTMLElement>>(
-  null as unknown as RefObject<HTMLElement>,
-);
-export const useGlobalScrollContext = () => useContext(GlobalScrollContext);

--- a/src/components/common/Layout/index.ts
+++ b/src/components/common/Layout/index.ts
@@ -1,2 +1,1 @@
-export * from "./context";
 export * from "./Layout";

--- a/src/components/common/Modal/Modal.tsx
+++ b/src/components/common/Modal/Modal.tsx
@@ -27,7 +27,7 @@ export const Modal = ({ children }: PropsWithChildren) => {
       {trigger}
       <Portal id="modal-portal">
         <div
-          className="absolute inset-0 z-[1300] flex touch-none items-center bg-black/50"
+          className="fixed inset-0 z-[1300] flex touch-none items-center bg-black/50"
           css={fadeInOut(open)}
           onTouchEnd={(event) => {
             if (event.target === event.currentTarget) event.preventDefault();

--- a/src/components/common/Navigation/SideBar/Category.tsx
+++ b/src/components/common/Navigation/SideBar/Category.tsx
@@ -4,19 +4,15 @@ import { useGetCategoryWithTag } from "@/application/hooks";
 import { PATH } from "@/application/util";
 import { Accordion } from "@/components/common/Accordion";
 import { useSetDrawerContext } from "@/components/common/Drawer";
-import { useGlobalScrollContext } from "@/components/common/Layout";
 
 export const Category = () => {
   const { data } = useGetCategoryWithTag();
   const setDrawerOpen = useSetDrawerContext();
   const router = useRouter();
-  const ref = useGlobalScrollContext();
 
   const onClickItem = (tagName: string) => {
     setDrawerOpen(false);
-    router
-      .push(PATH.getExploreByTagPath(tagName))
-      .then(() => ref.current?.scrollTo({ top: 0, behavior: "smooth" }));
+    router.push(PATH.getExploreByTagPath(tagName));
   };
 
   return <Accordion items={data} onClickItem={onClickItem} />;

--- a/src/components/common/Navigation/SideBar/SideBar.tsx
+++ b/src/components/common/Navigation/SideBar/SideBar.tsx
@@ -1,9 +1,9 @@
 import Link from "next/link";
-import { Suspense } from "react";
 
 import { Drawer } from "@/components/common/Drawer";
 import { Icon } from "@/components/common/Icon";
 import { Category } from "@/components/common/Navigation/SideBar/Category";
+import { SSRSuspense } from "@/components/common/Suspense";
 import { SearchInput } from "@/components/search";
 
 export const SideBar = () => {
@@ -16,11 +16,11 @@ export const SideBar = () => {
         <Link className="mt-8 mb-4 block py-8" href="/search">
           <SearchInput placeholder="당신이 생각한 '그 밈' 검색하기" />
         </Link>
-        <Suspense>
+        <SSRSuspense>
           <div className="px-14">
             <Category />
           </div>
-        </Suspense>
+        </SSRSuspense>
       </Drawer.Content>
     </Drawer>
   );

--- a/src/components/common/Photo/index.tsx
+++ b/src/components/common/Photo/index.tsx
@@ -10,6 +10,7 @@ import type { ComponentProps } from "react";
 interface Props extends Omit<ComponentProps<"img">, "alt" | "placeholder"> {
   unoptimized?: boolean;
   src?: string;
+  priority?: boolean;
 }
 
 const base64Blur =

--- a/src/components/meme/MemeInfo/MemeDetail.tsx
+++ b/src/components/meme/MemeInfo/MemeDetail.tsx
@@ -22,6 +22,7 @@ export const MemeDetail = ({ id }: Props) => {
     <article>
       <section className="relative mt-16 flex flex-col">
         <Photo
+          priority
           className="max-h-[70vh] min-h-[25vh] w-full rounded-15"
           height={imageHeight}
           src={imageUrl}

--- a/src/components/meme/MemeInfo/MemeDetail.tsx
+++ b/src/components/meme/MemeInfo/MemeDetail.tsx
@@ -14,6 +14,7 @@ export const MemeDetail = ({ id }: Props) => {
     name,
     description,
     image: { images },
+    isFetchedAfterMount,
   } = useMemeDetailById(id);
 
   const { imageUrl, imageWidth, imageHeight } = images[0];
@@ -33,10 +34,12 @@ export const MemeDetail = ({ id }: Props) => {
         </div>
         <div className="flex items-center justify-between pt-4 pb-16 font-suit text-12-bold-160 text-gray-500">
           <span>{createdDate.split("T")[0].replaceAll("-", ".")}</span>
-          <span className="flex gap-15">
-            <span>{`조회수 ${viewCount}`}</span>
-            <span>{`공유 ${shareCount}`}</span>
-          </span>
+          {isFetchedAfterMount && (
+            <span className="flex gap-15">
+              <span>{`조회수 ${viewCount}`}</span>
+              <span>{`공유 ${shareCount}`}</span>
+            </span>
+          )}
         </div>
       </section>
       <section className="mb-16 font-suit">

--- a/src/components/meme/MemeItem/MemeItem.tsx
+++ b/src/components/meme/MemeItem/MemeItem.tsx
@@ -25,7 +25,7 @@ export const MemeItem = memo(({ meme }: Props) => {
   return (
     <div {...longPress()}>
       {open && <MemeLongPress onClose={onClose} />}
-      <Link className="flex flex-col gap-6" href={`/memes/${meme.memeId}`}>
+      <Link className="flex flex-col gap-6" href={`/memes/${meme.memeId}`} prefetch={false}>
         <Photo
           unoptimized
           className="rounded-15"

--- a/src/components/meme/MemeItem/MemeItem.tsx
+++ b/src/components/meme/MemeItem/MemeItem.tsx
@@ -27,7 +27,6 @@ export const MemeItem = memo(({ meme }: Props) => {
       {open && <MemeLongPress onClose={onClose} />}
       <Link className="flex flex-col gap-6" href={`/memes/${meme.memeId}`} prefetch={false}>
         <Photo
-          unoptimized
           className="rounded-15"
           height={meme.image.images[0].imageHeight}
           src={meme.image.images[0].imageUrl}

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -1,6 +1,9 @@
 import "@/styles/globals.css";
 
 import type { AppProps } from "next/app";
+import Head from "next/head";
+import { useRouter } from "next/router";
+import { useEffect } from "react";
 
 import { QueryClientProvider } from "@/application/queryClient";
 import { QueryErrorBoundary } from "@/components/common/ErrorBoundary";
@@ -13,17 +16,34 @@ if (process.env.NEXT_PUBLIC_API_MOCKING === "enabled") {
 }
 
 const App = ({ Component, pageProps }: AppProps<DefaultPageProps>) => {
+  const router = useRouter();
+
+  useEffect(() => {
+    router.beforePopState((state) => {
+      state.options.scroll = false;
+      return true;
+    });
+  }, [router]);
+
   return (
-    <QueryClientProvider hydrateState={pageProps.hydrateState}>
-      <ToastProvider>
-        <Layout>
-          <QueryErrorBoundary>
-            <ToastContainer />
-            <Component {...pageProps} />
-          </QueryErrorBoundary>
-        </Layout>
-      </ToastProvider>
-    </QueryClientProvider>
+    <>
+      <Head>
+        <meta
+          content="width=device-width, initial-scale=1, maximum-scale=3, minimum-scale=1, user-scalable=yes"
+          name="viewport"
+        />
+      </Head>
+      <QueryClientProvider hydrateState={pageProps.hydrateState}>
+        <ToastProvider>
+          <Layout>
+            <QueryErrorBoundary>
+              <ToastContainer />
+              <Component {...pageProps} />
+            </QueryErrorBoundary>
+          </Layout>
+        </ToastProvider>
+      </QueryClientProvider>
+    </>
   );
 };
 

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -1,36 +1,29 @@
 import "@/styles/globals.css";
 
 import type { AppProps } from "next/app";
-import type { ComponentProps } from "react";
-import { Suspense } from "react";
 
 import { QueryClientProvider } from "@/application/queryClient";
 import { QueryErrorBoundary } from "@/components/common/ErrorBoundary";
 import { Layout } from "@/components/common/Layout";
 import { ToastContainer, ToastProvider } from "@/components/common/Toast";
+import type { DefaultPageProps } from "@/types";
 
 if (process.env.NEXT_PUBLIC_API_MOCKING === "enabled") {
   await import("../../mocks");
 }
 
-interface PageProps {
-  hydrateState: ComponentProps<typeof QueryClientProvider>["hydrateState"];
-}
-
-const App = ({ Component, pageProps }: AppProps<PageProps>) => {
+const App = ({ Component, pageProps }: AppProps<DefaultPageProps>) => {
   return (
-    <QueryClientProvider hydrateState={pageProps.hydrateState}>
-      <QueryErrorBoundary>
+    <QueryErrorBoundary>
+      <QueryClientProvider hydrateState={pageProps.hydrateState}>
         <ToastProvider>
           <Layout>
-            <Suspense fallback={<>hello</>}>
-              <ToastContainer />
-              <Component {...pageProps} />
-            </Suspense>
+            <ToastContainer />
+            <Component {...pageProps} />
           </Layout>
         </ToastProvider>
-      </QueryErrorBoundary>
-    </QueryClientProvider>
+      </QueryClientProvider>
+    </QueryErrorBoundary>
   );
 };
 

--- a/src/pages/_error.tsx
+++ b/src/pages/_error.tsx
@@ -11,7 +11,7 @@ const ErrorPage = ({ statusCode, err }: Props) => {
   return (
     <>
       <Navigation />
-      <div className="flex h-full flex-col items-center justify-center font-suit">
+      <div className="absolute left-1/2 top-1/2 flex -translate-x-2/4 -translate-y-2/4 flex-col items-center justify-center font-suit">
         <span className="text-32-bold-140 ">{statusCode} 오류 발생</span>
         <span className="mt-16 text-16-semibold-140 text-gray-600">
           이 페이지를 새로고침 해보세요.

--- a/src/pages/memes/[id].tsx
+++ b/src/pages/memes/[id].tsx
@@ -1,11 +1,8 @@
 import { dehydrate, QueryClient } from "@tanstack/react-query";
 import type { GetStaticPaths, GetStaticProps, NextPage } from "next";
-import Router from "next/router";
-import { useEffect } from "react";
 
 import { fetchMemeDetailById, fetchMemeTagsById } from "@/application/hooks";
 import { TITLE } from "@/application/util";
-import { useGlobalScrollContext } from "@/components/common/Layout";
 import { ExplorePageNavigation } from "@/components/common/Navigation";
 import { NextSeo } from "@/components/common/NextSeo";
 import { SSRSuspense } from "@/components/common/Suspense";
@@ -18,15 +15,6 @@ interface Props {
 }
 
 const MemeDetailPage: NextPage<Props> = ({ id, meme: { name, description } }) => {
-  const scrollRef = useGlobalScrollContext();
-
-  useEffect(() => {
-    const handleScrollTop = () => scrollRef.current?.scrollTo({ top: 0 });
-    Router.events.on("routeChangeComplete", handleScrollTop);
-
-    return () => Router.events.off("routeChangeComplete", handleScrollTop);
-  }, [scrollRef]);
-
   return (
     <>
       <NextSeo description={description} title={TITLE.memeDetail(name)} />

--- a/src/pages/memes/[id].tsx
+++ b/src/pages/memes/[id].tsx
@@ -1,31 +1,71 @@
-import type { NextPage } from "next";
-import { useRouter } from "next/router";
+import { dehydrate, QueryClient } from "@tanstack/react-query";
+import type { GetStaticPaths, GetStaticProps, NextPage } from "next";
 import { Suspense } from "react";
 
+import { prefetchMemeDetailById } from "@/application/hooks";
 import { DEFAULT_DESCRIPTION, TITLE } from "@/application/util";
 import { ExplorePageNavigation } from "@/components/common/Navigation";
 import { NextSeo } from "@/components/common/NextSeo";
+import { SSRSuspense } from "@/components/common/Suspense";
 import { MemeCTAList, MemeDetail, MemeTagList, RelativeMemeList } from "@/components/meme/MemeInfo";
+import type { DefaultPageProps } from "@/types";
 
-const MemeDetailPage: NextPage = () => {
-  const { query } = useRouter();
+interface Props {
+  id: string;
+}
 
+const MemeDetailPage: NextPage<Props> = ({ id }) => {
   return (
     <>
       <NextSeo description={DEFAULT_DESCRIPTION} title={TITLE.memeDetail} />
       <ExplorePageNavigation />
-      {query.id && (
-        <Suspense>
-          <MemeDetail id={query.id as string} />
-          <MemeTagList id={query.id as string} />
-          <MemeCTAList id={query.id as string} />
-          <Suspense>
-            <RelativeMemeList />
-          </Suspense>
-        </Suspense>
-      )}
+      <Suspense>
+        <MemeDetail id={id} />
+        <MemeTagList id={id} />
+        <MemeCTAList id={id} />
+      </Suspense>
+      <SSRSuspense>
+        {/* NOTE: 클라이언트 사이드에서만 렌더링 */}
+        <RelativeMemeList />
+      </SSRSuspense>
     </>
   );
+};
+
+export const getStaticPaths: GetStaticPaths = () => {
+  return {
+    paths: [],
+    fallback: "blocking",
+  };
+};
+
+export const getStaticProps: GetStaticProps<DefaultPageProps & Props, Partial<Props>> = async ({
+  params,
+}) => {
+  const id = params?.id;
+  const queryClient = new QueryClient();
+
+  /**
+   * @todo
+   *  1. 숫자 형식이 아닌 :id 요청 시 404 페이지로 이동
+   *  2. 데이터가 없는 페이지 요청 시 404 페이지로 이동
+   *    - id 값의 범위를 알아야 함
+   *    - 관련 api 필요
+   *    - try catch로 처리해 볼려 했으나, axios 500 에러를 제대로 catch 하지 못하는 이슈가 있어 실패
+   */
+  if (!id || isNaN(Number(id)))
+    return {
+      notFound: true,
+    };
+
+  await prefetchMemeDetailById(id, queryClient);
+
+  return {
+    props: {
+      hydrateState: dehydrate(queryClient),
+      id,
+    },
+  };
 };
 
 export default MemeDetailPage;

--- a/src/pages/memes/[id].tsx
+++ b/src/pages/memes/[id].tsx
@@ -44,34 +44,26 @@ export const getStaticProps: GetStaticProps<
   DefaultPageProps & Props,
   Partial<Pick<Props, "id">>
 > = async ({ params }) => {
-  const id = params?.id;
+  const id = params?.id as string;
   const queryClient = new QueryClient();
 
-  /**
-   * @todo
-   *  1. 숫자 형식이 아닌 :id 요청 시 404 페이지로 이동
-   *  2. 데이터가 없는 페이지 요청 시 404 페이지로 이동
-   *    - id 값의 범위를 알아야 함
-   *    - 관련 api 필요
-   *    - try catch로 처리해 볼려 했으나, axios 500 에러를 제대로 catch 하지 못하는 이슈가 있어 실패
-   */
-  if (!id || isNaN(Number(id)))
+  try {
+    const { description, name } = await fetchMemeDetailById(id, queryClient);
+    return {
+      props: {
+        hydrateState: dehydrate(queryClient),
+        id,
+        meme: {
+          description,
+          name,
+        },
+      },
+    };
+  } catch (e) {
     return {
       notFound: true,
     };
-
-  const { description, name } = await fetchMemeDetailById(id, queryClient);
-
-  return {
-    props: {
-      hydrateState: dehydrate(queryClient),
-      id,
-      meme: {
-        description,
-        name,
-      },
-    },
-  };
+  }
 };
 
 export default MemeDetailPage;

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -8,6 +8,7 @@
 
 html {
   font-size: 62.5%;
+  background: #f3f4f8;
   -webkit-touch-callout: none;
   -webkit-tap-highlight-color: rgba(0, 0, 0, 0);
 }

--- a/src/types/index.d.ts
+++ b/src/types/index.d.ts
@@ -1,3 +1,11 @@
+import type { ComponentProps } from "react";
+
+import type { QueryClientProvider } from "@/application/queryClient";
+
+export interface DefaultPageProps {
+  hydrateState: ComponentProps<typeof QueryClientProvider>["hydrateState"];
+}
+
 export interface Meme {
   memeId: number;
   name: string;

--- a/src/types/index.d.ts
+++ b/src/types/index.d.ts
@@ -16,7 +16,6 @@ export interface Meme {
   createdDate: string;
   modifiedDate: string;
 
-  // TODO Image interface 정의 필요
   image: {
     images: {
       imageId: number;
@@ -27,6 +26,5 @@ export interface Meme {
     count: number;
   };
 
-  tags?: string[];
   author?: string;
 }


### PR DESCRIPTION
## 📮 관련 이슈
- resolved: #42 

## ⛳️ 작업 내용

- [x] React Query 서버사이드에서 fetch 후 dehydrate
- [x] SEO를 위한 밈 데이터도 getStaticProps 에서 같이 전달
- [x] getStaticPath blocking 옵션으로 사용자 요청이 들어올 때 서버에서 페이지 생성 (첫 생성 시 약 800ms 정도 소요)
- [x] 잘못된 페이지 요청 시 404 응답 (ex. app.thismeme.me/memes/invalid)
- [x] 연관밈 (인기밈) 리스트는 클라이언트 사이드에서만 렌더링 (`<SSRSuspense />` 사용)

## 🌱 PR 포인트
-

## 📸 스크린샷
|스크린샷|
|:--:|
|<img width="1307" alt="image" src="https://user-images.githubusercontent.com/74011724/217421199-685adcfb-2a8f-4ef6-8ab4-3ec383fd95c3.png"> <img width="289" alt="image" src="https://user-images.githubusercontent.com/74011724/217421961-e50c55df-6cfd-45d3-a4e9-53a11b069300.png"> |
| 1. SEO 관련 meta 태그 <br /> 2. 밈 상세 데이터 서버 사이드에서 요청 후 pre rendering | 

## 📎 레퍼런스

<!-- 참고한 레퍼런스가 있다면 기록해주세요 -->