### PR TITLE
🍀 모달 컴포넌트 리팩토링 & 자잘한 UI 버그 수정

### DIFF
--- a/src/components/common/DropDown/DropDown.tsx
+++ b/src/components/common/DropDown/DropDown.tsx
@@ -52,7 +52,7 @@ const DropDownContents = ({
   children,
   width,
   ...rest
-}: PropsWithChildren<{ width: string; css?: CSSInterpolation }>) => {
+}: PropsWithChildren<{ width?: string; css?: CSSInterpolation }>) => {
   const isOpen = useContext(DropDownContext);
   return (
     <ul
@@ -68,6 +68,10 @@ const DropDownContents = ({
           transition: transform 0.4s ease, opacity 0.2s ease-in-out;
           ${!isOpen && "pointer-events: none;"}
         `,
+        width &&
+          css`
+            width: ${width}rem;
+          `,
         { opacity: isOpen ? 1 : 0 },
       ]}
       {...rest}

--- a/src/components/common/Modal/Modal.stories.tsx
+++ b/src/components/common/Modal/Modal.stories.tsx
@@ -1,5 +1,7 @@
 import type { ComponentMeta } from "@storybook/react";
 
+import { useModal } from "@/application/hooks";
+
 import { SignUpModal } from "./SignUpModal";
 
 export default {
@@ -8,9 +10,11 @@ export default {
 } as ComponentMeta<typeof SignUpModal>;
 
 export const SignUp = () => {
+  const modalProps = useModal();
   return (
     <>
-      <SignUpModal />
+      <button onClick={modalProps.onOpen}>open button</button>
+      <SignUpModal {...modalProps} />
     </>
   );
 };

--- a/src/components/common/Modal/Modal.tsx
+++ b/src/components/common/Modal/Modal.tsx
@@ -1,7 +1,8 @@
-import type { PropsWithChildren, ReactElement } from "react";
-import { Children, cloneElement, createContext, isValidElement, useContext } from "react";
+import type { PropsWithChildren } from "react";
+import { createContext, useContext } from "react";
 
-import { useClickOutside, useModal } from "@/application/hooks";
+import type { useModal } from "@/application/hooks";
+import { useClickOutside } from "@/application/hooks";
 import { fadeInOut } from "@/application/util/animation";
 import { Icon } from "@/components/common/Icon";
 import { Portal } from "@/components/common/Portal";
@@ -9,22 +10,16 @@ import { Portal } from "@/components/common/Portal";
 type ModalContextValue = ReturnType<typeof useModal>;
 const ModalContext = createContext<ModalContextValue>(null as unknown as ModalContextValue);
 
-export const Modal = ({ children }: PropsWithChildren) => {
-  const { open, onOpen, onClose } = useModal();
+export interface ModalProps {
+  open: boolean;
+  onOpen: () => void;
+  onClose: () => void;
+}
+export const Modal = ({ children, open, onOpen, onClose }: PropsWithChildren<ModalProps>) => {
   const ref = useClickOutside({ onClose });
-
-  const modalChildren = Children.toArray(children);
-
-  const trigger = modalChildren.find(
-    (child) => isValidElement(child) && child.type === ModalTriggerType,
-  );
-  const contents = modalChildren.filter(
-    (child) => isValidElement(child) && child.type !== ModalTriggerType,
-  );
 
   return (
     <ModalContext.Provider value={{ open, onOpen, onClose }}>
-      {trigger}
       <Portal id="modal-portal">
         <div
           className="fixed inset-0 z-[1300] flex items-center bg-black/50 touch-none"
@@ -34,7 +29,7 @@ export const Modal = ({ children }: PropsWithChildren) => {
           }}
         >
           <article className="m-auto rounded-10 border border-gray-400 bg-white px-16" ref={ref}>
-            {contents}
+            {children}
           </article>
         </div>
       </Portal>
@@ -54,28 +49,9 @@ const ModalHeader = () => {
   );
 };
 
-interface ModalContentProps {
-  children: (args: ModalContextValue) => ReactElement;
-}
-const ModalContent = ({ children }: ModalContentProps) => {
-  const context = useContext(ModalContext);
-  return children(context);
-};
+/**
+ * @todo
+ *   추후 submit 버튼 추가
+ */
 
-interface ModalTriggerProps {
-  children: ReactElement | ((args: ModalContextValue) => ReactElement);
-}
-const ModalTrigger = ({ children }: ModalTriggerProps) => {
-  const context = useContext(ModalContext);
-  const { open, onOpen, onClose } = context;
-  return typeof children === "function"
-    ? children(context)
-    : cloneElement(children, { onClick: () => (open ? onClose() : onOpen()) });
-};
-
-// @ts-expect-error : 컴포넌트의 type 만 얻기 위해 props type check off
-const ModalTriggerType = (<ModalTrigger />).type;
-
-Modal.Trigger = ModalTrigger;
 Modal.Header = ModalHeader;
-Modal.Content = ModalContent;

--- a/src/components/common/Modal/ProfileModal.tsx
+++ b/src/components/common/Modal/ProfileModal.tsx
@@ -11,7 +11,7 @@ export const ProfileModal = () => {
         <DropDown.Trigger>
           <Icon name="loginprofile" />
         </DropDown.Trigger>
-        <DropDown.Contents css={{ right: 0 }} width="34">
+        <DropDown.Contents css={{ right: 0, width: "34rem" }}>
           <DropDown.Content className="flex h-92 items-center justify-between p-16 font-suit text-22-bold-140">
             <Icon height={60} name="loginprofile" width={60} />@{user?.name}
             <Icon name="setting" />

--- a/src/components/common/Modal/SignUpModal.tsx
+++ b/src/components/common/Modal/SignUpModal.tsx
@@ -1,50 +1,45 @@
-import { Button } from "../Button";
-import { Icon } from "../Icon";
-import { RandomImage } from "../RandomImge";
+import { useMemo } from "react";
+
+import { Button } from "@/components/common/Button";
+import { Icon } from "@/components/common/Icon";
+import { RandomImage } from "@/components/common/RandomImge";
+
+import type { ModalProps } from "./Modal";
 import { Modal } from "./Modal";
 
-export const SignUpModal = () => {
+export const SignUpModal = (props: ModalProps) => {
+  // FIX: Modal이 닫힐 때 랜덤 밈이 바뀌는 현상 수정
+  const meme = useMemo(
+    () => <RandomImage className="-mb-[calc(1.4em-3.2rem)/2] inline-block h-32 w-32 rounded-8" />,
+    [],
+  );
+
   return (
-    <>
-      <Modal>
-        <Modal.Trigger>
-          <Button className="h-32 w-32">
-            <Icon name="notloginprofile" />
+    <Modal {...props}>
+      <Modal.Header />
+      <div className="m-auto w-300 rounded-24 px-8 pb-24">
+        <section className="align-left mt-36 mb-10 text-left font-suit text-32-bold-140">
+          <div>킹 받는 {meme} 을</div>
+          <div>바로 찾아서</div>
+          <div>보낼 수 있어요!</div>
+        </section>
+        <span className="font-suit text-16-semibold-140 text-gray-800">
+          This meme 에 오신 걸 환영합니다
+        </span>
+        <section className="m-auto flex w-116 justify-between pt-32">
+          <Button className="h-50 w-50 rounded-10 border border-solid border-light-gray-30">
+            <Icon name="google" />
           </Button>
-        </Modal.Trigger>
-        <Modal.Header />
-        <Modal.Content>
-          {() => (
-            <div className="m-auto w-300 rounded-24 px-8 pb-24">
-              <section className="align-left mt-36 mb-10 text-left font-suit text-32-bold-140">
-                <div>
-                  킹 받는{" "}
-                  <RandomImage className="-mb-[calc(1.4em-3.2rem)/2] inline-block h-32 w-32 rounded-8" />
-                  을
-                </div>
-                <div>바로 찾아서</div>
-                <div>보낼 수 있어요!</div>
-              </section>
-              <span className="font-suit text-16-semibold-140 text-gray-800">
-                This meme 에 오신 걸 환영합니다
-              </span>
-              <section className="m-auto flex w-116 justify-between pt-32">
-                <Button className="h-50 w-50 rounded-10 border border-solid border-light-gray-30">
-                  <Icon name="google" />
-                </Button>
-                <Button
-                  as="a"
-                  className="h-50 w-50 rounded-10 bg-[#FEE500]"
-                  href={`${process.env.NEXT_PUBLIC_API_URL}/oauth2/authorization/kakao`}
-                  size="large"
-                >
-                  <Icon name="kakao2" />
-                </Button>
-              </section>
-            </div>
-          )}
-        </Modal.Content>
-      </Modal>
-    </>
+          <Button
+            as="a"
+            className="h-50 w-50 rounded-10 bg-[#FEE500]"
+            href={`${process.env.NEXT_PUBLIC_API_URL}/oauth2/authorization/kakao`}
+            size="large"
+          >
+            <Icon name="kakao2" />
+          </Button>
+        </section>
+      </div>
+    </Modal>
   );
 };

--- a/src/components/common/Modal/SignUpModal.tsx
+++ b/src/components/common/Modal/SignUpModal.tsx
@@ -1,5 +1,3 @@
-import { useMemo } from "react";
-
 import { Button } from "@/components/common/Button";
 import { Icon } from "@/components/common/Icon";
 import { RandomImage } from "@/components/common/RandomImge";
@@ -8,18 +6,16 @@ import type { ModalProps } from "./Modal";
 import { Modal } from "./Modal";
 
 export const SignUpModal = (props: ModalProps) => {
-  // FIX: Modal이 닫힐 때 랜덤 밈이 바뀌는 현상 수정
-  const meme = useMemo(
-    () => <RandomImage className="-mb-[calc(1.4em-3.2rem)/2] inline-block h-32 w-32 rounded-8" />,
-    [],
-  );
-
   return (
     <Modal {...props}>
       <Modal.Header />
       <div className="m-auto w-300 rounded-24 px-8 pb-24">
         <section className="align-left mt-36 mb-10 text-left font-suit text-32-bold-140">
-          <div>킹 받는 {meme} 을</div>
+          <div>
+            킹 받는{" "}
+            <RandomImage className="-mb-[calc(1.4em-3.2rem)/2] inline-block h-32 w-32 rounded-8" />
+            을
+          </div>
           <div>바로 찾아서</div>
           <div>보낼 수 있어요!</div>
         </section>

--- a/src/components/common/Navigation/Profile/Profile.tsx
+++ b/src/components/common/Navigation/Profile/Profile.tsx
@@ -1,11 +1,24 @@
-import { useAuth, useIsMount } from "@/application/hooks";
+import { useAuth, useIsMount, useModal } from "@/application/hooks";
+import { Button } from "@/components/common/Button";
+import { Icon } from "@/components/common/Icon";
 import { ProfileModal, SignUpModal } from "@/components/common/Modal";
 
 export const Profile = () => {
   const { isLogin } = useAuth();
+  const modalProps = useModal();
 
   const isMount = useIsMount();
+
   if (!isMount) return null;
 
-  return <>{isLogin ? <ProfileModal /> : <SignUpModal />}</>;
+  if (isLogin) return <ProfileModal />;
+
+  return (
+    <>
+      <Button className="h-32 w-32" onClick={modalProps.onOpen}>
+        <Icon name="notloginprofile" />
+      </Button>
+      <SignUpModal {...modalProps} />
+    </>
+  );
 };

--- a/src/components/explore/EmptyMemesView/EmptyMemesView.tsx
+++ b/src/components/explore/EmptyMemesView/EmptyMemesView.tsx
@@ -5,7 +5,7 @@ import { RandomImage } from "@/components/common/RandomImge";
 export const EmptyMemesView = () => {
   return (
     <div className="absolute left-1/2 top-1/2 flex -translate-y-2/4 -translate-x-2/4 flex-col items-center justify-center font-suit">
-      <span className="text-32-bold-140">
+      <span className="whitespace-nowrap text-32-bold-140">
         당신이 찾는{" "}
         <Link href="/">
           <RandomImage className="-mb-[calc(1.4em-3.2rem)/2] inline-block h-32 w-32 rounded-8" />

--- a/src/components/home/DropDown/MemeSortDropDown.tsx
+++ b/src/components/home/DropDown/MemeSortDropDown.tsx
@@ -1,5 +1,5 @@
 import type { MouseEvent } from "react";
-import { useEffect, useState } from "react";
+import { useState } from "react";
 import { css } from "twin.macro";
 
 import { useAuth } from "@/application/hooks";
@@ -38,7 +38,7 @@ export const MemeSortDropDown = () => {
           )}
         </DropDown.Trigger>
       </div>
-      <DropDown.Contents width="34">
+      <DropDown.Contents css={{ width: "34rem" }}>
         {isLogin && (
           <DropDown.Content
             className="flex h-56 items-center p-16 font-suit text-18-bold-140 hover:bg-primary-100"

--- a/src/components/meme/MemeInfo/Button/NativeShareButton.tsx
+++ b/src/components/meme/MemeInfo/Button/NativeShareButton.tsx
@@ -24,7 +24,7 @@ export const NativeShareButton = ({ title, text, url, onSuccess, onError }: Prop
       onError?.();
       return;
     }
-    navigator.share({ title, text, url }).then(onSuccess).catch(onError);
+    navigator.share({ title, text, url }).then(onSuccess);
   };
 
   return (

--- a/src/components/meme/MemeInfo/DropDown/MemeExport.tsx
+++ b/src/components/meme/MemeInfo/DropDown/MemeExport.tsx
@@ -1,3 +1,5 @@
+import tw from "twin.macro";
+
 import { useDownload, useMemeDetailById, useToast } from "@/application/hooks";
 import { DropDown } from "@/components/common/DropDown";
 import { Icon } from "@/components/common/Icon";
@@ -35,11 +37,11 @@ export const MemeExport = ({ id }: Props) => {
   return (
     <DropDown>
       <DropDown.Trigger>
-        <span className="mb-16 flex h-40 w-40 items-center justify-center rounded-10 bg-black shadow-[0_0_20px_rgba(255,255,255,0.3)]">
+        <span className="absolute top-16 right-16 flex h-40 w-40 items-center justify-center rounded-10 bg-black shadow-[0_0_20px_rgba(255,255,255,0.3)]">
           <Icon color="white" name="meatball" />
         </span>
       </DropDown.Trigger>
-      <DropDown.Contents css={{ right: 0 }} width="34">
+      <DropDown.Contents css={tw`w-full right-0 top-72`}>
         <DropDown.Content
           className="flex h-56 items-center p-16 font-suit text-18-bold-140 hover:bg-primary-100"
           onClick={handleImageDownload}

--- a/src/components/meme/MemeInfo/MemeCTAList.tsx
+++ b/src/components/meme/MemeInfo/MemeCTAList.tsx
@@ -1,4 +1,6 @@
-import { useToast } from "@/application/hooks";
+import { useModal, useToast } from "@/application/hooks";
+import { Button } from "@/components/common/Button";
+import { Icon } from "@/components/common/Icon";
 import { CollectionSaveButton } from "@/components/meme/MemeInfo/Button/CollectionSaveButton";
 import { MemeShareModal } from "@/components/meme/MemeInfo/Modal";
 
@@ -7,12 +9,16 @@ interface Props {
 }
 export const MemeCTAList = ({ id }: Props) => {
   const { show } = useToast();
+  const modalProps = useModal();
 
   const handleCollectionClick = () => show("콜렉션에 저장했습니다!");
 
   return (
     <div className="flex w-full gap-10 py-40">
-      <MemeShareModal id={id} />
+      <Button className="h-52 w-52 shrink-0 rounded-10 bg-gray-900" onClick={modalProps.onOpen}>
+        <Icon color="stroke-white" name="memeShare" />
+      </Button>
+      <MemeShareModal id={id} {...modalProps} />
       <CollectionSaveButton onClick={handleCollectionClick} />
     </div>
   );

--- a/src/components/meme/MemeInfo/MemeDetail.tsx
+++ b/src/components/meme/MemeInfo/MemeDetail.tsx
@@ -29,9 +29,7 @@ export const MemeDetail = ({ id }: Props) => {
           src={imageUrl}
           width={imageWidth}
         />
-        <div className="absolute right-16 top-16">
-          <MemeExport id={id} />
-        </div>
+        <MemeExport id={id} />
         <div className="flex items-center justify-between pt-4 pb-16 font-suit text-12-bold-160 text-gray-500">
           <span>{createdDate.split("T")[0].replaceAll("-", ".")}</span>
           {isFetchedAfterMount && (

--- a/src/components/meme/MemeInfo/Modal/MemeShareModal.tsx
+++ b/src/components/meme/MemeInfo/Modal/MemeShareModal.tsx
@@ -1,7 +1,6 @@
 import { useMemeDetailById, useToast } from "@/application/hooks";
 import { PAGE_URL } from "@/application/util";
-import { Button } from "@/components/common/Button";
-import { Icon } from "@/components/common/Icon";
+import type { ModalProps } from "@/components/common/Modal";
 import { Modal } from "@/components/common/Modal";
 import { Photo } from "@/components/common/Photo";
 import {
@@ -10,10 +9,10 @@ import {
   NativeShareButton,
 } from "@/components/meme/MemeInfo/Button";
 
-interface Props {
+interface Props extends ModalProps {
   id: string;
 }
-export const MemeShareModal = ({ id }: Props) => {
+export const MemeShareModal = ({ id, ...rest }: Props) => {
   const { show } = useToast();
 
   const {
@@ -28,55 +27,44 @@ export const MemeShareModal = ({ id }: Props) => {
   const showNativeShareErrorToast = () => show("공유하기가 지원되지 않습니다.");
 
   return (
-    <Modal>
-      <Modal.Trigger>
-        <Button className="h-52 w-52 shrink-0 rounded-10 bg-gray-900">
-          <Icon color="stroke-white" name="memeShare" />
-        </Button>
-      </Modal.Trigger>
+    <Modal {...rest}>
       <Modal.Header />
-      <Modal.Content>
-        {({ onClose }) => (
-          <>
-            <Photo className="my-24 h-187 w-300 rounded-15" src={src} />
-            <ul className="mx-auto mb-32 flex h-77 w-fit gap-16 whitespace-nowrap text-gray-600">
-              <li className="relative flex flex-col items-center gap-8">
-                <KakaoShareButton
-                  resource={{
-                    url: PAGE_URL,
-                    imageUrl: src,
-                    title: name,
-                    description,
-                  }}
-                />
-                <span className="absolute bottom-0 font-suit text-12-bold-160">카카오로 공유</span>
-              </li>
-              <li className="relative flex flex-col items-center gap-8">
-                <ClipboardCopyButton
-                  target={PAGE_URL}
-                  onSuccess={() => {
-                    onClose();
-                    showClipboardCopyToast();
-                  }}
-                />
-                <span className="absolute bottom-0 font-suit text-12-bold-160">링크 복사</span>
-              </li>
-              <li className="relative flex flex-col items-center gap-8">
-                <NativeShareButton
-                  text={description}
-                  title={name}
-                  url={PAGE_URL}
-                  onError={() => {
-                    onClose();
-                    showNativeShareErrorToast();
-                  }}
-                />
-                <span className="absolute bottom-0 font-suit text-12-bold-160">다른 앱 공유</span>
-              </li>
-            </ul>
-          </>
-        )}
-      </Modal.Content>
+      <Photo className="my-24 w-300 rounded-15" src={src} />
+      <ul className="mx-auto mb-32 flex h-77 w-fit gap-16 whitespace-nowrap text-gray-600">
+        <li className="relative flex flex-col items-center gap-8">
+          <KakaoShareButton
+            resource={{
+              url: PAGE_URL,
+              imageUrl: src,
+              title: name,
+              description,
+            }}
+          />
+          <span className="absolute bottom-0 font-suit text-12-bold-160">카카오로 공유</span>
+        </li>
+        <li className="relative flex flex-col items-center gap-8">
+          <ClipboardCopyButton
+            target={PAGE_URL}
+            onSuccess={() => {
+              rest.onClose();
+              showClipboardCopyToast();
+            }}
+          />
+          <span className="absolute bottom-0 font-suit text-12-bold-160">링크 복사</span>
+        </li>
+        <li className="relative flex flex-col items-center gap-8">
+          <NativeShareButton
+            text={description}
+            title={name}
+            url={PAGE_URL}
+            onError={() => {
+              rest.onClose();
+              showNativeShareErrorToast();
+            }}
+          />
+          <span className="absolute bottom-0 font-suit text-12-bold-160">다른 앱 공유</span>
+        </li>
+      </ul>
     </Modal>
   );
 };

--- a/src/components/meme/MemeInfo/Modal/MemeShareModal.tsx
+++ b/src/components/meme/MemeInfo/Modal/MemeShareModal.tsx
@@ -12,7 +12,7 @@ import {
 interface Props extends ModalProps {
   id: string;
 }
-export const MemeShareModal = ({ id, ...rest }: Props) => {
+export const MemeShareModal = ({ id, ...modalProps }: Props) => {
   const { show } = useToast();
 
   const {
@@ -27,7 +27,7 @@ export const MemeShareModal = ({ id, ...rest }: Props) => {
   const showNativeShareErrorToast = () => show("공유하기가 지원되지 않습니다.");
 
   return (
-    <Modal {...rest}>
+    <Modal {...modalProps}>
       <Modal.Header />
       <Photo className="my-24 w-300 rounded-15" src={src} />
       <ul className="mx-auto mb-32 flex h-77 w-fit gap-16 whitespace-nowrap text-gray-600">
@@ -46,7 +46,7 @@ export const MemeShareModal = ({ id, ...rest }: Props) => {
           <ClipboardCopyButton
             target={PAGE_URL}
             onSuccess={() => {
-              rest.onClose();
+              modalProps.onClose();
               showClipboardCopyToast();
             }}
           />
@@ -58,7 +58,7 @@ export const MemeShareModal = ({ id, ...rest }: Props) => {
             title={name}
             url={PAGE_URL}
             onError={() => {
-              rest.onClose();
+              modalProps.onClose();
               showNativeShareErrorToast();
             }}
           />

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -19,11 +19,12 @@ html {
   -moz-user-select: none;
   -ms-user-select: none;
   user-select: none;
+  background: #f3f4f8 !important;
+
 }
 
 body {
   color: black;
-  background: #f3f4f8 !important;
   -webkit-tap-highlight-color: rgba(0, 0, 0, 0);
   overscroll-behavior-y: none;
 }


### PR DESCRIPTION
## 📮 관련 이슈
- resolved: #이슈번호

## ⛳️ 작업 내용

<!-- 작업한 사항을 간략하게 적어주세요 -->
### `<Modal />` 제어 컴포넌트 방식으로 변경
```tsx
// Props
export interface ModalProps {
  open: boolean;
  onOpen: () => void;
  onClose: () => void;
}

// 모달 예시

  <Modal {...props}>
    <Modal.Header />
      <span className="font-suit text-16-semibold-140 text-gray-800">
        This meme 에 오신 걸 환영합니다
      </span>
  </Modal>

// 사용 예시
 const modalProps = useModal()

  <>
    <Button className="h-32 w-32" onClick={modalProps.onOpen}>
      <Icon name="notloginprofile" />
    </Button>
    <SignUpModal {...modalProps} />
  </>
```
- 현재 `<Modal />`, `<Modal.Header />` 만 남아있음
- 추후 마이페이지 관련 모달 제작 시 `<Modal.Footer />` 등 작성 필요
- 트리거 컴포넌트는 외부에서 관리

### 일부 UI 버그 수정
- 로그인 모달 닫을 시 랜덤 밈 변경되는 현상 수정
- 글자가 2줄 되는 문제로 EmptyMemeView `whitespace-nowrap` 반영
- 밈 상세 페이지 ... 드롭다운 위치 수정
- 다른 앱 공유하기 취소할 시 에러 토스트 안띄우게 수정
- DropDown.Contents width props 삭제 후 css props로 변경

## 🌱 PR 포인트
-

## 📸 스크린샷
|스크린샷|스크린샷|
|:--:|:--:|
|파일첨부바람|파일첨부바람|

## 📎 레퍼런스

<!-- 참고한 레퍼런스가 있다면 기록해주세요 -->