### PR TITLE
:recycle: Refactor: 로그인 여부 로컬스토리지 저장 로직 삭제

### DIFF
--- a/mocks/handlers/account/index.ts
+++ b/mocks/handlers/account/index.ts
@@ -1,10 +1,12 @@
 import { rest } from "msw";
 
-export const getMyAccount = rest.post(
+export const getMyAccount = rest.get(
   `${process.env.NEXT_PUBLIC_API_URL}/accounts/me`,
   async (req, res, ctx) => {
+    const isAuth = req.headers.get("authorization");
+
     return res(
-      ctx.status(200),
+      ctx.status(isAuth ? 200 : 401),
       ctx.json({
         createDate: new Date().toISOString(),
         email: "test@gmail.com",

--- a/mocks/handlers/auth/index.ts
+++ b/mocks/handlers/auth/index.ts
@@ -6,11 +6,11 @@ export const refresh = rest.post(
     const refreshToken = req.cookies.refreshToken;
 
     // NOTE: refreshToken 이 없거나 만료되었으면 401, 정상 200
-    const status = refreshToken ? 401 : Math.random() < 0.3 ? 401 : 200;
+    const status = !refreshToken ? 401 : Math.random() < 0.3 ? 401 : 200;
 
     // NOTE: Internal Server Error 500
     return res(
-      ctx.status(Math.random() > 0.8 ? 500 : status),
+      ctx.status(Math.random() > 0.85 ? 500 : status),
       ctx.json({
         accessToken: "Refresh Test",
       }),

--- a/mocks/handlers/auth/index.ts
+++ b/mocks/handlers/auth/index.ts
@@ -3,10 +3,14 @@ import { rest } from "msw";
 export const refresh = rest.post(
   `${process.env.NEXT_PUBLIC_API_URL}/token/refresh`,
   async (req, res, ctx) => {
-    const status = Math.floor(Math.random() * 100) % 4 ? 200 : 401;
+    const refreshToken = req.cookies.refreshToken;
 
+    // NOTE: refreshToken 이 없거나 만료되었으면 401, 정상 200
+    const status = refreshToken ? 401 : Math.random() < 0.3 ? 401 : 200;
+
+    // NOTE: Internal Server Error 500
     return res(
-      ctx.status(status),
+      ctx.status(Math.random() > 0.8 ? 500 : status),
       ctx.json({
         accessToken: "Refresh Test",
       }),

--- a/mocks/handlers/index.ts
+++ b/mocks/handlers/index.ts
@@ -1,3 +1,4 @@
+import * as account from "./account";
 import * as auth from "./auth";
 import * as meme from "./meme";
 import * as post from "./post";
@@ -10,4 +11,5 @@ export const handlers = [
   ...Object.values(tags),
   ...Object.values(meme),
   ...Object.values(search),
+  ...Object.values(account),
 ];

--- a/src/application/hooks/api/account/index.ts
+++ b/src/application/hooks/api/account/index.ts
@@ -1,5 +1,5 @@
 import type { UseQueryOptions } from "@tanstack/react-query";
-import { useQuery } from "@tanstack/react-query";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 
 import { api } from "@/infra/api";
 
@@ -13,3 +13,13 @@ export const useGetMyAccount = ({ enabled }: UseQueryOptions) =>
     enabled,
     staleTime: Infinity,
   });
+
+export const useLogout = () => {
+  const queryClient = useQueryClient();
+  return useMutation(api.auth.logout, {
+    onSuccess: () => {
+      api.auth.deleteAccessToken();
+      queryClient.setQueryData(QUERY_KEYS.getMyAccount, null);
+    },
+  });
+};

--- a/src/application/hooks/api/account/index.ts
+++ b/src/application/hooks/api/account/index.ts
@@ -1,17 +1,15 @@
-import type { UseQueryOptions } from "@tanstack/react-query";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 
 import { api } from "@/infra/api";
 
 import { QUERY_KEYS } from "./queryKey";
 
-export const useGetMyAccount = ({ enabled }: UseQueryOptions) => {
+export const useGetMyAccount = () => {
   const queryClient = useQueryClient();
   return useQuery({
     suspense: false,
     queryKey: QUERY_KEYS.getMyAccount,
     queryFn: api.account.getMyAccount,
-    enabled,
     onError: () => {
       queryClient.setQueryData(QUERY_KEYS.getMyAccount, null);
     },

--- a/src/application/hooks/api/account/index.ts
+++ b/src/application/hooks/api/account/index.ts
@@ -5,14 +5,18 @@ import { api } from "@/infra/api";
 
 import { QUERY_KEYS } from "./queryKey";
 
-export const useGetMyAccount = ({ enabled }: UseQueryOptions) =>
-  useQuery({
+export const useGetMyAccount = ({ enabled }: UseQueryOptions) => {
+  const queryClient = useQueryClient();
+  return useQuery({
     suspense: false,
     queryKey: QUERY_KEYS.getMyAccount,
     queryFn: api.account.getMyAccount,
     enabled,
-    staleTime: Infinity,
+    onError: () => {
+      queryClient.setQueryData(QUERY_KEYS.getMyAccount, null);
+    },
   });
+};
 
 export const useLogout = () => {
   const queryClient = useQueryClient();

--- a/src/application/hooks/domain/auth/useAuth.ts
+++ b/src/application/hooks/domain/auth/useAuth.ts
@@ -4,7 +4,7 @@ import { useGetMyAccount, useLogout } from "@/application/hooks";
 import { api } from "@/infra/api";
 
 export const useAuth = () => {
-  const { data } = useGetMyAccount({ enabled: true });
+  const { data } = useGetMyAccount();
   const { mutate: logout } = useLogout();
 
   const login = useCallback((token: string) => {

--- a/src/application/hooks/domain/auth/useAuth.ts
+++ b/src/application/hooks/domain/auth/useAuth.ts
@@ -1,45 +1,20 @@
 import { useCallback } from "react";
 
-import { useGetMyAccount, useLocalStorage } from "@/application/hooks";
-import { LOCAL_STORAGE_KEY } from "@/application/util";
+import { useGetMyAccount, useLogout } from "@/application/hooks";
 import { api } from "@/infra/api";
 
-/**
- * @description
- *
- * useAuth
- * 1. method: login, logout
- * 2. property: user, isLogin (SSR false)
- *
- * withAuth hoc
- *   useAuth isLogin == false, return LoginModal
- *
- * getServerSideProps (로그인 모달로 처리하므로 쓸일 없을 듯)
- *   check req.header.authorization
- *   if AT not exist, return redirect to auth page
- *   else return props user data
- *
- */
-
 export const useAuth = () => {
-  const [isLogin, setIsLogin] = useLocalStorage<boolean>(LOCAL_STORAGE_KEY.isLogin, {
-    defaultValue: false,
-  });
-  const { data } = useGetMyAccount({ enabled: isLogin });
+  const { data } = useGetMyAccount({ enabled: true });
+  const { mutate: logout } = useLogout();
 
-  const logout = useCallback(() => api.auth.logout().then(() => setIsLogin(false)), [setIsLogin]);
-  const login = useCallback(
-    (token: string) => {
-      api.auth.setAccessToken(token);
-      setIsLogin(true);
-    },
-    [setIsLogin],
-  );
+  const login = useCallback((token: string) => {
+    api.auth.setAccessToken(token);
+  }, []);
 
   return {
     logout,
     login,
-    isLogin,
+    isLogin: Boolean(data),
     user: data,
   };
 };

--- a/src/components/common/Modal/ProfileModal.tsx
+++ b/src/components/common/Modal/ProfileModal.tsx
@@ -4,7 +4,7 @@ import { DropDown } from "../DropDown";
 import { Icon } from "../Icon";
 
 export const ProfileModal = () => {
-  const { user } = useAuth();
+  const { user, logout } = useAuth();
   return (
     <>
       <DropDown>
@@ -26,7 +26,10 @@ export const ProfileModal = () => {
               <span className="text-16-semibold-140">collect</span>
             </section>
           </DropDown.Content>
-          <DropDown.Content className="mt-24 flex h-60 items-center justify-center bg-black font-suit text-18-bold-140 text-white">
+          <DropDown.Content
+            className="mt-24 flex h-60 items-center justify-center bg-black font-suit text-18-bold-140 text-white"
+            onClick={() => logout()}
+          >
             로그아웃
           </DropDown.Content>
         </DropDown.Contents>

--- a/src/components/home/SharedMeme/SharedMemeList.tsx
+++ b/src/components/home/SharedMeme/SharedMemeList.tsx
@@ -10,7 +10,7 @@ interface Props {
 export const SharedMemeList = ({ name }: Props) => {
   return (
     <div>
-      <div className="my-16 flex justify-between font-suit text-22-bold-140">
+      <div className="flex justify-between py-16 font-suit text-22-bold-140">
         {`@${name} 이 공유했던 밈`}
         <Icon
           height={32}

--- a/src/infra/api/auth/index.ts
+++ b/src/infra/api/auth/index.ts
@@ -1,7 +1,7 @@
 import type { AxiosInstance, AxiosRequestConfig } from "axios";
 import { isAxiosError } from "axios";
 
-import { IS_CSR, LOCAL_STORAGE_KEY, safeLocalStorage } from "@/application/util";
+import { IS_CSR } from "@/application/util";
 import type { RefreshResponse } from "@/infra/api/auth/types";
 
 export class AuthApi {
@@ -26,7 +26,6 @@ export class AuthApi {
       const origin = error.config as AxiosRequestConfig;
 
       if (origin.url === "/token/refresh" && status === 401) {
-        safeLocalStorage.remove(LOCAL_STORAGE_KEY.isLogin);
         location.reload();
       }
 
@@ -45,6 +44,10 @@ export class AuthApi {
 
   setAccessToken = (token: string) => {
     this.api.defaults.headers.common["Authorization"] = `Bearer ${token}`;
+  };
+
+  deleteAccessToken = () => {
+    delete this.api.defaults.headers.common["Authorization"];
   };
 
   logout = () => {

--- a/src/infra/api/auth/index.ts
+++ b/src/infra/api/auth/index.ts
@@ -14,10 +14,10 @@ export class AuthApi {
     /**
      * @desc
      *  401 에러 시 토큰 갱신 후 이전 api 재요청 합니다
-     *  401 제외 상태코드 또는 이미 재요청 한 api일 경우 오류를 반환합니다
+     *  이외 상태코드 또는 이미 재요청 한 api일 경우 오류를 반환합니다
      *
      *  refresh api가 401을 반환하면 재로그인을 해야 합니다
-     *  - AT 삭제 후 페이지 강제 리로드로 일단 처리
+     *  - 오류 반환 후, 유저 정보를 불러오는 useGetMyAccount 에서 setQueryData null 로 처리
      */
     api.interceptors.response.use(null, async (error) => {
       if (!isAxiosError(error)) return Promise.reject(error);
@@ -25,9 +25,7 @@ export class AuthApi {
       const status = Number(error.response?.status);
       const origin = error.config as AxiosRequestConfig;
 
-      if (origin.url === "/token/refresh" && status === 401) {
-        location.reload();
-      }
+      if (origin.url === "/token/refresh" && status === 401) return Promise.reject(error);
 
       if (status !== 401 || origin.headers?.retry) return Promise.reject(error);
 

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -1,6 +1,5 @@
 import type { NextPage } from "next";
 import { useRouter } from "next/router";
-import { Suspense } from "react";
 
 import { useAuth } from "@/application/hooks";
 import { DEFAULT_DESCRIPTION, TITLE } from "@/application/util";
@@ -27,9 +26,9 @@ const HomePage: NextPage = () => {
             router.push("/search");
           }}
         />
-        <Suspense>
+        <SSRSuspense fallback={<div className="h-84" />}>
           <PopularTagList />
-        </Suspense>
+        </SSRSuspense>
         {isLogin && <SharedMemeList name={user?.name} />}
         <MemeSortDropDown />
         <SSRSuspense>


### PR DESCRIPTION
## 📮 관련 이슈
- resolved: #이슈번호

## ⛳️ 작업 내용
### refresh api 401 에러시 페이지 무한 reload 되는 현상 수정
`getMyAccount` hook을 페이지 첫 로드시 바로 불러오는 것이 원인이었음


> 1. AT 없는 상태로 getMyAccount 요청
> 2. accounts/me api에서 401 반환
> 3. refresh api 요청
> 4. RT에 문제가 있으면 401 반환
> 5. 페이지 reload 후 1번부터 반복

reload를 하지 않고, `useGetMyAccount` hook의 `onError` 콜백에서 데이터 null 처리
```tsx
 useQuery({
    suspense: false,
    queryKey: QUERY_KEYS.getMyAccount,
    queryFn: api.account.getMyAccount,
    onError: () => {
      queryClient.setQueryData(QUERY_KEYS.getMyAccount, null);
    },
  })
```

### refresh, accounts/me msw handler 수정
- 200, 401, 500 status 고려

![image](https://user-images.githubusercontent.com/74011724/219101762-208371a4-c9ac-4354-8aa0-e3478550f275.png)
- 브라우저 쿠키 설정으로 로그인 된 상태를 mocking 할 수 있습니다

<!-- 작업한 사항을 간략하게 적어주세요 -->

## 🌱 PR 포인트


## 📸 스크린샷
|스크린샷|스크린샷|
|:--:|:--:|
|파일첨부바람|파일첨부바람|

## 📎 레퍼런스

<!-- 참고한 레퍼런스가 있다면 기록해주세요 -->